### PR TITLE
Enabled custom CSS rule names

### DIFF
--- a/tests/compilation/test_css.py
+++ b/tests/compilation/test_css.py
@@ -14,7 +14,8 @@ import pytest
 from typing import Any, Dict, List
 from webwidgets.compilation.html.html_node import HTMLNode
 from webwidgets.compilation.html.html_tags import TextNode
-from webwidgets.compilation.css.css import compile_css, CSSRule, CompiledCSS, apply_css
+from webwidgets.compilation.css.css import compile_css, CSSRule, CompiledCSS, \
+    apply_css, default_rule_namer
 
 
 class TestCompileCSS:
@@ -508,3 +509,23 @@ class TestApplyCSS:
         apply_css(compiled_css, tree)
         assert "class" not in tree.attributes
         assert tree.to_html() == '<htmlnode></htmlnode>'
+
+
+class TestRuleNaming:
+    def test_default_rule_namer(self):
+        rules = [CSSRule(None, {"color": "red"}),
+                 CSSRule(None, {"margin": "0"})]
+        for i, rule in enumerate(rules):
+            rule.name = default_rule_namer(rules=rules, index=i)
+        assert rules[0].name == "r0"
+        assert rules[1].name == "r1"
+
+    def test_default_rule_namer_override(self):
+        rules = [CSSRule("first", {"color": "red"}),
+                 CSSRule("second", {"margin": "0"})]
+        assert rules[0].name == "first"
+        assert rules[1].name == "second"
+        for i, rule in enumerate(rules):
+            rule.name = default_rule_namer(rules=rules, index=i)
+        assert rules[0].name == "r0"
+        assert rules[1].name == "r1"

--- a/tests/compilation/test_css.py
+++ b/tests/compilation/test_css.py
@@ -532,7 +532,7 @@ class TestApplyCSS:
         assert tree.to_html() == '<htmlnode></htmlnode>'
 
 
-class TestRuleNaming:
+class TestDefaultRuleNamer:
     def test_default_rule_namer(self):
         rules = [CSSRule(None, {"color": "red"}),
                  CSSRule(None, {"margin": "0"})]

--- a/tests/compilation/test_css.py
+++ b/tests/compilation/test_css.py
@@ -260,6 +260,27 @@ class TestCompileCSS:
         assert TestCompileCSS._serialize_mapping(
             compiled_css2.mapping) == expected_mapping
 
+    @pytest.mark.parametrize("rule_namer, names", [
+        (lambda _, i: f"rule{i}", ["rule0", "rule1", "rule2"]),
+        (lambda _, i: f"rule-{i + 1}", ["rule-1", "rule-2", "rule-3"]),
+        (lambda r, i: f"{list(r[i].declarations.items())[0][0]}{i}", [
+            "az0", "bz1", "bz2"]),
+        (lambda r, i: f"{list(r[i].declarations.items())[0][0][0]}{i}", [
+            "a0", "b1", "b2"]),
+        (lambda r, i: f"r{list(r[i].declarations.items())[0][1]}-{i}", [
+            "r10-1", "r4-2", "r5-0"]),
+    ])
+    def test_custom_rule_names(self, rule_namer, names):
+        tree = HTMLNode(
+            style={"az": "5", "bz": "4"},
+            children=[
+                HTMLNode(style={"az": "5"}),
+                HTMLNode(style={"bz": "10"}),
+            ]
+        )
+        compiled_css = compile_css(tree, rule_namer=rule_namer)
+        assert [r.name for r in compiled_css.rules] == names
+
 
 class TestCompiledCSS:
     def test_export_custom_compiled_css(self):

--- a/tests/compilation/test_css.py
+++ b/tests/compilation/test_css.py
@@ -11,12 +11,37 @@
 # =======================================================================
 
 import pytest
+from typing import Any, Dict, List
 from webwidgets.compilation.html.html_node import HTMLNode
 from webwidgets.compilation.html.html_tags import TextNode
-from webwidgets.compilation.css.css import compile_css, CompiledCSS, apply_css
+from webwidgets.compilation.css.css import compile_css, CSSRule, CompiledCSS, apply_css
 
 
 class TestCompileCSS:
+    @staticmethod
+    def _serialize_rules(rules: List[CSSRule]) -> List[Dict[str, Any]]:
+        """Utility function to convert a list of :py:class:`CSSRule` objects
+        into a dictionary that can be used in testing.
+
+        :param rules: List of :py:class:`CSSRule` objects.
+        :type rules: List[CSSRule]
+        :return: List of the member variables of each :py:class:`CSSRule`.
+        :rtype: Dict[int, Any]
+        """
+        return [vars(rule) for rule in rules]
+
+    @staticmethod
+    def _serialize_mapping(mapping: Dict[int, List[CSSRule]]) -> Dict[int, List[str]]:
+        """Utility function to convert a :py:attr:`CompiledCSS.mapping` object
+        into a dictionary that can be used in testing.
+
+        :param mapping: :py:attr:`CompiledCSS.mapping` object.
+        :type mapping: Dict[int, List[CSSRule]]
+        :return: Dictionary mapping each node ID to the name of the rules that
+            achieve the same style.
+        """
+        return {i: [r.name for r in rules] for i, rules in mapping.items()}
+
     def test_argument_type(self):
         """Compares compilation when given a node object versus a list of
         nodes.
@@ -30,10 +55,10 @@ class TestCompileCSS:
         )
 
         # Define expected compilation results
-        expected_rules = {
-            'r0': {'a': '5'},
-            'r1': {'b': '4'}
-        }
+        expected_rules = [
+            {"name": "r0", "declarations": {"a": "5"}},
+            {"name": "r1", "declarations": {"b": "4"}}
+        ]
         expected_mapping = {
             id(tree): ['r0', 'r1'],
             id(tree.children[0]): ['r0']
@@ -45,8 +70,10 @@ class TestCompileCSS:
         # Check results of compilation
         assert compiled_css.trees == [tree]
         assert [id(t) for t in compiled_css.trees] == [id(tree)]
-        assert compiled_css.rules == expected_rules
-        assert compiled_css.mapping == expected_mapping
+        assert TestCompileCSS._serialize_rules(
+            compiled_css.rules) == expected_rules
+        assert TestCompileCSS._serialize_mapping(
+            compiled_css.mapping) == expected_mapping
 
         # Compile tree as list of one node
         compiled_css2 = compile_css([tree])
@@ -54,8 +81,10 @@ class TestCompileCSS:
         # Check results of compilation again (should be unchanged)
         assert compiled_css2.trees == [tree]
         assert [id(t) for t in compiled_css2.trees] == [id(tree)]
-        assert compiled_css2.rules == expected_rules
-        assert compiled_css2.mapping == expected_mapping
+        assert TestCompileCSS._serialize_rules(
+            compiled_css2.rules) == expected_rules
+        assert TestCompileCSS._serialize_mapping(
+            compiled_css2.mapping) == expected_mapping
 
     def test_basic_compilation(self):
         # Create some HTML nodes with different styles
@@ -72,17 +101,19 @@ class TestCompileCSS:
             id(node1), id(node2), id(node3)]
 
         # Check that the rules are correctly generated
-        expected_rules = {
-            'r0': {'color': 'blue'},
-            'r1': {'margin': '0'},
-            'r2': {'padding': '0'}
-        }
-        assert compiled_css.rules == expected_rules
+        expected_rules = [
+            {"name": "r0", "declarations": {"color": "blue"}},
+            {"name": "r1", "declarations": {"margin": "0"}},
+            {"name": "r2", "declarations": {"padding": "0"}}
+        ]
+        assert TestCompileCSS._serialize_rules(
+            compiled_css.rules) == expected_rules
 
         # Check that the mapping is correctly generated
         expected_mapping = {id(node1): ['r1', 'r2'], id(
             node2): ['r0', 'r1'], id(node3): ['r1', 'r2']}
-        assert compiled_css.mapping == expected_mapping
+        assert TestCompileCSS._serialize_mapping(
+            compiled_css.mapping) == expected_mapping
 
     def test_nested_compilation_one_tree(self):
         # Create some nested HTML nodes
@@ -104,13 +135,14 @@ class TestCompileCSS:
         assert [id(t) for t in compiled_css.trees] == [id(tree)]
 
         # Check that the rules are correctly generated
-        expected_rules = {
-            'r0': {'color': 'blue'},
-            'r1': {'margin': '0'},
-            'r2': {'margin': '5'},
-            'r3': {'padding': '0'}
-        }
-        assert compiled_css.rules == expected_rules
+        expected_rules = [
+            {"name": "r0", "declarations": {"color": "blue"}},
+            {"name": "r1", "declarations": {"margin": "0"}},
+            {"name": "r2", "declarations": {"margin": "5"}},
+            {"name": "r3", "declarations": {"padding": "0"}}
+        ]
+        assert TestCompileCSS._serialize_rules(
+            compiled_css.rules) == expected_rules
 
         # Check that the mapping is correctly generated
         expected_mapping = {
@@ -120,7 +152,8 @@ class TestCompileCSS:
             id(tree.children[0].children[0]): [],
             id(tree.children[1].children[0]): []
         }
-        assert compiled_css.mapping == expected_mapping
+        assert TestCompileCSS._serialize_mapping(
+            compiled_css.mapping) == expected_mapping
 
     def test_nested_compilation_two_trees(self):
         # Create 2 trees
@@ -146,13 +179,14 @@ class TestCompileCSS:
             id(tree1), id(tree2)]
 
         # Check that the rules are correctly generated
-        expected_rules = {
-            'r0': {'color': 'red'},
-            'r1': {'margin': '10'},
-            'r2': {'margin': '5'},
-            'r3': {'padding': '0'}
-        }
-        assert compiled_css.rules == expected_rules
+        expected_rules = [
+            {"name": "r0", "declarations": {"color": "red"}},
+            {"name": "r1", "declarations": {"margin": "10"}},
+            {"name": "r2", "declarations": {"margin": "5"}},
+            {"name": "r3", "declarations": {"padding": "0"}}
+        ]
+        assert TestCompileCSS._serialize_rules(
+            compiled_css.rules) == expected_rules
 
         # Check that the mapping is correctly generated
         expected_mapping = {
@@ -161,7 +195,8 @@ class TestCompileCSS:
             id(tree2): ['r2', 'r3'],
             id(tree2.children[0]): ['r1']
         }
-        assert compiled_css.mapping == expected_mapping
+        assert TestCompileCSS._serialize_mapping(
+            compiled_css.mapping) == expected_mapping
 
     def test_rules_numbered_in_order(self):
         """Test that rules are numbered in lexicographical order"""
@@ -174,14 +209,15 @@ class TestCompileCSS:
             ]
         )
         compiled_css = compile_css(tree)
-        expected_rules = {
-            'r0': {'a': '10'},
-            'r1': {'a': '5'},
-            'r2': {'b': '10'},
-            'r3': {'b': '4'},
-            'r4': {'c': '5'}
-        }
-        assert compiled_css.rules == expected_rules
+        expected_rules = [
+            {"name": "r0", "declarations": {"a": "10"}},
+            {"name": "r1", "declarations": {"a": "5"}},
+            {"name": "r2", "declarations": {"b": "10"}},
+            {"name": "r3", "declarations": {"b": "4"}},
+            {"name": "r4", "declarations": {"c": "5"}},
+        ]
+        assert TestCompileCSS._serialize_rules(
+            compiled_css.rules) == expected_rules
 
     def test_duplicate_node(self):
         """Test that adding the same node twice does not impact compilation"""
@@ -193,11 +229,11 @@ class TestCompileCSS:
                 HTMLNode(style={"b": "10"}),
             ]
         )
-        expected_rules = {
-            'r0': {'a': '5'},
-            'r1': {'b': '10'},
-            'r2': {'b': '4'}
-        }
+        expected_rules = [
+            {"name": "r0", "declarations": {"a": "5"}},
+            {"name": "r1", "declarations": {"b": "10"}},
+            {"name": "r2", "declarations": {"b": "4"}}
+        ]
         expected_mapping = {
             id(tree): ['r0', 'r2'],
             id(tree.children[0]): ['r0'],
@@ -206,8 +242,10 @@ class TestCompileCSS:
         compiled_css = compile_css([tree])
         assert compiled_css.trees == [tree]
         assert [id(t) for t in compiled_css.trees] == [id(tree)]
-        assert compiled_css.rules == expected_rules
-        assert compiled_css.mapping == expected_mapping
+        assert TestCompileCSS._serialize_rules(
+            compiled_css.rules) == expected_rules
+        assert TestCompileCSS._serialize_mapping(
+            compiled_css.mapping) == expected_mapping
 
         # Compiling the tree and one of its children, which should already be
         # included recursively from the tree itself and should not affect the
@@ -216,25 +254,20 @@ class TestCompileCSS:
         assert compiled_css2.trees == [tree, tree.children[0]]
         assert [id(t) for t in compiled_css2.trees] == [
             id(tree), id(tree.children[0])]
-        assert compiled_css2.rules == expected_rules
-        assert compiled_css2.mapping == expected_mapping
+        assert TestCompileCSS._serialize_rules(
+            compiled_css2.rules) == expected_rules
+        assert TestCompileCSS._serialize_mapping(
+            compiled_css2.mapping) == expected_mapping
 
 
 class TestCompiledCSS:
     def test_export_custom_compiled_css(self):
-        rules = {
-            "r0": {
-                "margin": "0",
-                "padding": "0"
-            },
-            "r1": {
-                "color": "blue"
-            },
-            "r2": {
-                "background-color": "white",
-                "font-size": "16px"
-            }
-        }
+        rules = [
+            CSSRule(name="r0", declarations={"margin": "0", "padding": "0"}),
+            CSSRule(name="r1", declarations={"color": "blue"}),
+            CSSRule(name="r2", declarations={
+                    "background-color": "white", "font-size": "16px"})
+        ]
         compiled_css = CompiledCSS(trees=None,
                                    rules=rules,
                                    mapping=None)
@@ -364,12 +397,12 @@ class TestApplyCSS:
 
         # Compiling and applying CSS to the tree
         compiled_css = compile_css(tree)
-        assert compiled_css.rules == {
-            "r0": {"color": "blue"},
-            "r1": {"color": "green"},
-            "r2": {"margin": "0"},
-            "r3": {"padding": "0"}
-        }
+        assert TestCompileCSS._serialize_rules(compiled_css.rules) == [
+            {"name": "r0", "declarations": {"color": "blue"}},
+            {"name": "r1", "declarations": {"color": "green"}},
+            {"name": "r2", "declarations": {"margin": "0"}},
+            {"name": "r3", "declarations": {"padding": "0"}}
+        ]
         apply_css(compiled_css, tree)
 
         # Checking the tree's new classes
@@ -398,7 +431,7 @@ class TestApplyCSS:
         )
         html_before = tree.to_html()
         compiled_css = compile_css(tree)
-        assert compiled_css.rules == {}
+        assert compiled_css.rules == []
         apply_css(compiled_css, tree)
         html_after = tree.to_html()
 

--- a/tests/utility/test_representation.py
+++ b/tests/utility/test_representation.py
@@ -102,7 +102,7 @@ class TestRepresentation:
         assert str(obj) == "Outer(d={'1': Inner(a=1), '2': Inner(a=2)})"
 
     def test_repr_with_nested_dict_of_list(self):
-        """Test case with dict - containing list of objects - as attribute"""
+        """Test case with dict containing list of objects as attribute"""
         class Inner(ReprMixin):
             def __init__(self, a):
                 self.a = a

--- a/tests/utility/test_representation.py
+++ b/tests/utility/test_representation.py
@@ -1,0 +1,75 @@
+# =======================================================================
+#
+#  This file is part of WebWidgets, a Python package for designing web
+#  UIs.
+#
+#  You should have received a copy of the MIT License along with
+#  WebWidgets. If not, see <https://opensource.org/license/mit>.
+#
+#  Copyright(C) 2025, mlaasri
+#
+# =======================================================================
+
+from webwidgets.utility.representation import RepresentedWithVars
+
+
+class TestRepresentation:
+    def test_repr_without_attributes(self):
+        """Test case without any attributes"""
+        class EmptyClass(RepresentedWithVars):
+            pass
+        empty_obj = EmptyClass()
+        assert str(empty_obj) == "EmptyClass()"
+
+    def test_repr_with_none_value(self):
+        """Test case with None value for an attribute"""
+        class MyClass(RepresentedWithVars):
+            def __init__(self, a, b=None):
+                self.a = a
+                self.b = b
+        obj = MyClass(1)
+        assert str(obj) == "MyClass(a=1, b=None)"
+
+    def test_repr_with_multiple_attributes(self):
+        """Test case with multiple attributes"""
+        class ComplexClass(RepresentedWithVars):
+            def __init__(self, a, b, c=None, d=None):
+                self.a = a
+                self.b = b
+                self.c = c
+                self.d = d
+        obj = ComplexClass(1, 2, c=3, d=4)
+        assert str(obj) == "ComplexClass(a=1, b=2, c=3, d=4)"
+
+    def test_repr_with_multiple_types(self):
+        """Test case with multiple types of attributes"""
+        class MixedTypeClass(RepresentedWithVars):
+            def __init__(self, a: int, b: float, c: str):
+                self.a = a
+                self.b = b
+                self.c = c
+        obj = MixedTypeClass(1, 2.5, "test")
+        assert str(obj) == "MixedTypeClass(a=1, b=2.5, c='test')"
+
+    def test_repr_with_large_number_of_attributes(self):
+        """Test case with a large number of attributes"""
+        class LargeObject(RepresentedWithVars):
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+        obj = LargeObject(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8, i=9, j=10)
+        assert str(
+            obj) == "LargeObject(a=1, b=2, c=3, d=4, e=5, f=6, g=7, h=8, i=9, j=10)"
+
+    def test_repr_with_nested_objects(self):
+        """Test case with nested object as attribute"""
+        class Inner(RepresentedWithVars):
+            def __init__(self, a, b):
+                self.a = a
+                self.b = b
+
+        class Outer(RepresentedWithVars):
+            def __init__(self, obj=None):
+                self.obj = obj
+        complex_obj = Outer(obj=Inner(a=1, b=2))
+        assert str(complex_obj) == "Outer(obj=Inner(a=1, b=2))"

--- a/tests/utility/test_representation.py
+++ b/tests/utility/test_representation.py
@@ -10,20 +10,20 @@
 #
 # =======================================================================
 
-from webwidgets.utility.representation import RepresentedWithVars
+from webwidgets.utility.representation import ReprMixin
 
 
 class TestRepresentation:
     def test_repr_without_attributes(self):
         """Test case without any attributes"""
-        class EmptyClass(RepresentedWithVars):
+        class EmptyClass(ReprMixin):
             pass
         empty_obj = EmptyClass()
         assert str(empty_obj) == "EmptyClass()"
 
     def test_repr_with_none_value(self):
         """Test case with None value for an attribute"""
-        class MyClass(RepresentedWithVars):
+        class MyClass(ReprMixin):
             def __init__(self, a, b=None):
                 self.a = a
                 self.b = b
@@ -32,7 +32,7 @@ class TestRepresentation:
 
     def test_repr_with_multiple_attributes(self):
         """Test case with multiple attributes"""
-        class ComplexClass(RepresentedWithVars):
+        class ComplexClass(ReprMixin):
             def __init__(self, a, b, c=None, d=None):
                 self.a = a
                 self.b = b
@@ -43,7 +43,7 @@ class TestRepresentation:
 
     def test_repr_with_multiple_types(self):
         """Test case with multiple types of attributes"""
-        class MixedTypeClass(RepresentedWithVars):
+        class MixedTypeClass(ReprMixin):
             def __init__(self, a: int, b: float, c: str):
                 self.a = a
                 self.b = b
@@ -53,7 +53,7 @@ class TestRepresentation:
 
     def test_repr_with_large_number_of_attributes(self):
         """Test case with a large number of attributes"""
-        class LargeObject(RepresentedWithVars):
+        class LargeObject(ReprMixin):
             def __init__(self, **kwargs):
                 for k, v in kwargs.items():
                     setattr(self, k, v)
@@ -63,12 +63,12 @@ class TestRepresentation:
 
     def test_repr_with_nested_objects(self):
         """Test case with nested object as attribute"""
-        class Inner(RepresentedWithVars):
+        class Inner(ReprMixin):
             def __init__(self, a, b):
                 self.a = a
                 self.b = b
 
-        class Outer(RepresentedWithVars):
+        class Outer(ReprMixin):
             def __init__(self, obj=None):
                 self.obj = obj
         complex_obj = Outer(obj=Inner(a=1, b=2))
@@ -76,11 +76,11 @@ class TestRepresentation:
 
     def test_repr_with_nested_list(self):
         """Test case with list of objects as attribute"""
-        class Inner(RepresentedWithVars):
+        class Inner(ReprMixin):
             def __init__(self, a):
                 self.a = a
 
-        class Outer(RepresentedWithVars):
+        class Outer(ReprMixin):
             def __init__(self):
                 self.obj = [Inner(1), Inner(2)]
         obj = Outer()
@@ -88,11 +88,11 @@ class TestRepresentation:
 
     def test_repr_with_nested_dict(self):
         """Test case with list of objects as attribute"""
-        class Inner(RepresentedWithVars):
+        class Inner(ReprMixin):
             def __init__(self, a):
                 self.a = a
 
-        class Outer(RepresentedWithVars):
+        class Outer(ReprMixin):
             def __init__(self):
                 self.d = {
                     "1": Inner(1),
@@ -103,11 +103,11 @@ class TestRepresentation:
 
     def test_repr_with_nested_dict_of_list(self):
         """Test case with dict - containing list of objects - as attribute"""
-        class Inner(RepresentedWithVars):
+        class Inner(ReprMixin):
             def __init__(self, a):
                 self.a = a
 
-        class Outer(RepresentedWithVars):
+        class Outer(ReprMixin):
             def __init__(self):
                 self.d = {
                     "odd": [Inner(1), Inner(3)],

--- a/tests/utility/test_representation.py
+++ b/tests/utility/test_representation.py
@@ -73,3 +73,46 @@ class TestRepresentation:
                 self.obj = obj
         complex_obj = Outer(obj=Inner(a=1, b=2))
         assert str(complex_obj) == "Outer(obj=Inner(a=1, b=2))"
+
+    def test_repr_with_nested_list(self):
+        """Test case with list of objects as attribute"""
+        class Inner(RepresentedWithVars):
+            def __init__(self, a):
+                self.a = a
+
+        class Outer(RepresentedWithVars):
+            def __init__(self):
+                self.obj = [Inner(1), Inner(2)]
+        obj = Outer()
+        assert str(obj) == "Outer(obj=[Inner(a=1), Inner(a=2)])"
+
+    def test_repr_with_nested_dict(self):
+        """Test case with list of objects as attribute"""
+        class Inner(RepresentedWithVars):
+            def __init__(self, a):
+                self.a = a
+
+        class Outer(RepresentedWithVars):
+            def __init__(self):
+                self.d = {
+                    "1": Inner(1),
+                    "2": Inner(2)
+                }
+        obj = Outer()
+        assert str(obj) == "Outer(d={'1': Inner(a=1), '2': Inner(a=2)})"
+
+    def test_repr_with_nested_dict_of_list(self):
+        """Test case with dict - containing list of objects - as attribute"""
+        class Inner(RepresentedWithVars):
+            def __init__(self, a):
+                self.a = a
+
+        class Outer(RepresentedWithVars):
+            def __init__(self):
+                self.d = {
+                    "odd": [Inner(1), Inner(3)],
+                    "even": [Inner(2)]
+                }
+        obj = Outer()
+        assert str(obj) == "Outer(d={'odd': [Inner(a=1), " \
+            "Inner(a=3)], 'even': [Inner(a=2)]})"

--- a/webwidgets/compilation/css/__init__.py
+++ b/webwidgets/compilation/css/__init__.py
@@ -10,4 +10,4 @@
 #
 # =======================================================================
 
-from .css import compile_css, CompiledCSS, apply_css
+from .css import compile_css, CSSRule, CompiledCSS, apply_css

--- a/webwidgets/compilation/css/__init__.py
+++ b/webwidgets/compilation/css/__init__.py
@@ -10,4 +10,5 @@
 #
 # =======================================================================
 
-from .css import compile_css, CSSRule, CompiledCSS, apply_css
+from .css import compile_css, CSSRule, CompiledCSS, apply_css, \
+    default_rule_namer

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -13,11 +13,11 @@
 import itertools
 from typing import Dict, List, Union
 from webwidgets.compilation.html.html_node import HTMLNode
-from webwidgets.utility.representation import RepresentedWithVars
+from webwidgets.utility.representation import ReprMixin
 from webwidgets.utility.validation import validate_css_identifier
 
 
-class CSSRule(RepresentedWithVars):
+class CSSRule(ReprMixin):
     """A rule in a style sheet.
     """
 
@@ -36,7 +36,7 @@ class CSSRule(RepresentedWithVars):
         self.declarations = declarations
 
 
-class CompiledCSS(RepresentedWithVars):
+class CompiledCSS(ReprMixin):
     """A utility class to hold compiled CSS rules.
     """
 

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -91,7 +91,8 @@ def default_rule_namer(rules: List[CSSRule], index: int) -> str:
     """Default rule naming function. Returns a string like "r{i}" where {i} is
     the index of the rule.
 
-    :param rules: List of all compiled CSSRule objects.
+    :param rules: List of all compiled CSSRule objects. This argument is not
+        used in this function, but it can be used in other naming strategies.
     :type rules: List[CSSRule]
     :param index: Index of the rule being named.
     :type index: int
@@ -147,7 +148,9 @@ def compile_css(trees: Union[HTMLNode, List[HTMLNode]],
         other than the default `"r0"`, `"r1"`, etc. For example, it can be used
         to achieve something similar to Tailwind CSS and name rules according
         to what they achieve, e.g. by prefixing their name with `"m"` for
-        margin rules or `"p"` for padding rules.
+        margin rules or `"p"` for padding rules. Note that all rule names will
+        be validated with the :py:func:`validate_css_identifier` function
+        before being written into CSS code.
 
         Defaults to the :py:func:`default_rule_namer` function which implements
         a default naming strategy where each rule is named `"r{i}"` where `i`

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -162,7 +162,7 @@ def compile_css(trees: Union[HTMLNode, List[HTMLNode]],
     properties = set(itertools.chain.from_iterable(s.items()
                      for s in styles.values()))
     rules = [CSSRule(None, dict([p]))  # Initializing with no name
-             for i, p in enumerate(sorted(properties))]
+             for p in sorted(properties)]
     for i, rule in enumerate(rules):  # Assigning name from callback
         rule.name = rule_namer(rules, i)
     mapping = {node_id: sorted([r for r in rules if

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -165,9 +165,9 @@ def compile_css(trees: Union[HTMLNode, List[HTMLNode]],
              for p in sorted(properties)]
     for i, rule in enumerate(rules):  # Assigning name from callback
         rule.name = rule_namer(rules, i)
-    mapping = {node_id: sorted([r for r in rules if
-                                set(r.declarations.items()).issubset(style.items())],
-                               key=lambda r: r.name)
+    rules = sorted(rules, key=lambda r: r.name)  # Sorting by name
+    mapping = {node_id: [r for r in rules if
+                         set(r.declarations.items()).issubset(style.items())]
                for node_id, style in styles.items()}
     return CompiledCSS(trees, rules, mapping)
 

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -20,11 +20,9 @@ class CSSRule:
     """A rule in a style sheet.
     """
 
-    def __init__(self, id: int, name: str, declarations: Dict[str, str]):
-        """Stores the id, name, and declarations of a rule.
+    def __init__(self, name: str, declarations: Dict[str, str]):
+        """Stores the name and declarations of the rule.
 
-        :param id: The unique identifier for the rule.
-        :type id: int
         :param name: The name of the rule.
         :type name: str
         :param declarations: The CSS declarations for the rule, specified as a
@@ -32,7 +30,6 @@ class CSSRule:
             corresponding values. For example: `{'color': 'red'}`
         :type declarations: Dict[str, str]
         """
-        self.id = id
         self.name = name
         self.declarations = declarations
 

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -62,9 +62,9 @@ class CompiledCSS(ReprMixin):
         """Converts the `rules` dictionary of the :py:class:`CompiledCSS`
         object into CSS code.
 
-        Each rule name is converted to a class selector and each property name
-        is validated with :py:func:`validate_css_identifier` before being
-        converted.
+        Rule names are converted to class selectors. Note that each rule and
+        property name is validated with :py:func:`validate_css_identifier`
+        before being converted. 
 
         :param indent_size: The number of spaces to use for indentation in the
             CSS code. Defaults to 4.
@@ -78,6 +78,7 @@ class CompiledCSS(ReprMixin):
 
         # Writing down each rule
         for i, rule in enumerate(self.rules):
+            validate_css_identifier(rule.name)
             css_code += f".{rule.name}" + " {\n"
             for property_name, value in rule.declarations.items():
                 validate_css_identifier(property_name)

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -140,8 +140,10 @@ def compile_css(trees: Union[HTMLNode, List[HTMLNode]]) -> CompiledCSS:
     styles = {k: v for tree in trees for k, v in tree.get_styles().items()}
     properties = set(itertools.chain.from_iterable(s.items()
                      for s in styles.values()))
-    rules = [CSSRule(f"r{i}", dict([p]))
+    rules = [CSSRule(None, dict([p]))  # Initializing with no name
              for i, p in enumerate(sorted(properties))]
+    for i, rule in enumerate(rules):  # Assigning name from callback
+        rule.name = default_rule_namer(rules=rules, index=i)
     mapping = {node_id: sorted([r for r in rules if
                                 set(r.declarations.items()).issubset(style.items())],
                                key=lambda r: r.name)
@@ -189,3 +191,10 @@ def apply_css(css: CompiledCSS, tree: HTMLNode) -> None:
     # Recursively applying the CSS rules to all child nodes of the tree
     for child in tree.children:
         apply_css(css, child)
+
+
+def default_rule_namer(rules: List[CSSRule], index: int) -> str:
+    """Default rule naming function. Returns a string like "r{id}" where {id}
+    is the index of the rule.
+    """
+    return f'r{index}'

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -115,11 +115,11 @@ def compile_css(trees: Union[HTMLNode, List[HTMLNode]]) -> CompiledCSS:
 
         >>> compiled_css = compile_css(tree)
         >>> print(compiled_css.rules)
-        {
-            'r0': {'color': 'blue'},
-            'r1': {'margin': '0'},
-            'r2': {'padding': '0'}
-        }
+        [
+            CSSRule(name='r0', declarations={'color': 'blue'}),
+            CSSRule(name='r1', declarations={'margin': '0'}),
+            CSSRule(name='r2', declarations={'padding': '0'})
+        ]
 
     :param trees: A single tree or a list of trees to optimize over. All
         children are recursively included in the compilation.

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -87,23 +87,9 @@ class CompiledCSS(ReprMixin):
         return css_code
 
 
-def default_rule_namer(rules: List[CSSRule], index: int) -> str:
-    """Default rule naming function. Returns a string like "r{i}" where {i} is
-    the index of the rule.
-
-    :param rules: List of all compiled CSSRule objects. This argument is not
-        used in this function, but it can be used in other naming strategies.
-    :type rules: List[CSSRule]
-    :param index: Index of the rule being named.
-    :type index: int
-    :return: A string like `"r{i}"` where `i` is the index of the rule.
-    """
-    return f'r{index}'
-
-
 def compile_css(trees: Union[HTMLNode, List[HTMLNode]],
                 rule_namer: Callable[[List[CSSRule], int],
-                                     str] = default_rule_namer) -> CompiledCSS:
+                                     str] = None) -> CompiledCSS:
     """Computes optimized CSS rules from the given HTML trees.
 
     The main purpose of this function is to reduce the number of CSS rules
@@ -167,6 +153,9 @@ def compile_css(trees: Union[HTMLNode, List[HTMLNode]],
     if isinstance(trees, HTMLNode):
         trees = [trees]
 
+    # Handling default rule_namer
+    rule_namer = default_rule_namer if rule_namer is None else rule_namer
+
     # For now, we just return a simple mapping where each CSS property defines
     # its own ruleset
     styles = {k: v for tree in trees for k, v in tree.get_styles().items()}
@@ -223,3 +212,17 @@ def apply_css(css: CompiledCSS, tree: HTMLNode) -> None:
     # Recursively applying the CSS rules to all child nodes of the tree
     for child in tree.children:
         apply_css(css, child)
+
+
+def default_rule_namer(rules: List[CSSRule], index: int) -> str:
+    """Default rule naming function. Returns a string like "r{i}" where {i} is
+    the index of the rule.
+
+    :param rules: List of all compiled CSSRule objects. This argument is not
+        used in this function, but it can be used in other naming strategies.
+    :type rules: List[CSSRule]
+    :param index: Index of the rule being named.
+    :type index: int
+    :return: A string like `"r{i}"` where `i` is the index of the rule.
+    """
+    return f'r{index}'

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -16,6 +16,27 @@ from webwidgets.compilation.html.html_node import HTMLNode
 from webwidgets.utility.validation import validate_css_identifier
 
 
+class CSSRule:
+    """A rule in a style sheet.
+    """
+
+    def __init__(self, id: int, name: str, declarations: Dict[str, str]):
+        """Stores the id, name, and declarations of a rule.
+
+        :param id: The unique identifier for the rule.
+        :type id: int
+        :param name: The name of the rule.
+        :type name: str
+        :param declarations: The CSS declarations for the rule, specified as a
+            dictionary where keys are property names and values are their
+            corresponding values. For example: `{'color': 'red'}`
+        :type declarations: Dict[str, str]
+        """
+        self.id = id
+        self.name = name
+        self.declarations = declarations
+
+
 class CompiledCSS:
     """A utility class to hold compiled CSS rules.
     """

--- a/webwidgets/compilation/css/css.py
+++ b/webwidgets/compilation/css/css.py
@@ -13,10 +13,11 @@
 import itertools
 from typing import Dict, List, Union
 from webwidgets.compilation.html.html_node import HTMLNode
+from webwidgets.utility.representation import RepresentedWithVars
 from webwidgets.utility.validation import validate_css_identifier
 
 
-class CSSRule:
+class CSSRule(RepresentedWithVars):
     """A rule in a style sheet.
     """
 
@@ -30,11 +31,12 @@ class CSSRule:
             corresponding values. For example: `{'color': 'red'}`
         :type declarations: Dict[str, str]
         """
+        super().__init__()
         self.name = name
         self.declarations = declarations
 
 
-class CompiledCSS:
+class CompiledCSS(RepresentedWithVars):
     """A utility class to hold compiled CSS rules.
     """
 
@@ -51,6 +53,7 @@ class CompiledCSS:
             that achieve the same style.
         :type mapping: Dict[int, List[CSSRule]]
         """
+        super().__init__()
         self.trees = trees
         self.rules = rules
         self.mapping = mapping

--- a/webwidgets/compilation/html/html_node.py
+++ b/webwidgets/compilation/html/html_node.py
@@ -13,12 +13,12 @@
 import copy
 import itertools
 from typing import Any, Dict, List, Union
-from webwidgets.utility.representation import RepresentedWithVars
+from webwidgets.utility.representation import ReprMixin
 from webwidgets.utility.sanitizing import sanitize_html_text
 from webwidgets.utility.validation import validate_html_class
 
 
-class HTMLNode(RepresentedWithVars):
+class HTMLNode(ReprMixin):
     """Represents an HTML node (for example, a div or a span).
     """
 

--- a/webwidgets/compilation/html/html_node.py
+++ b/webwidgets/compilation/html/html_node.py
@@ -35,6 +35,7 @@ class HTMLNode(RepresentedWithVars):
         :param style: Dictionary of CSS properties for the node. Defaults to an empty dictionary.
         :type style: Dict[str, str]
         """
+        super().__init__()
         self.children = [] if children is None else children
         self.attributes = {} if attributes is None else attributes
         self.style = {} if style is None else style

--- a/webwidgets/compilation/html/html_node.py
+++ b/webwidgets/compilation/html/html_node.py
@@ -13,11 +13,12 @@
 import copy
 import itertools
 from typing import Any, Dict, List, Union
+from webwidgets.utility.representation import RepresentedWithVars
 from webwidgets.utility.sanitizing import sanitize_html_text
 from webwidgets.utility.validation import validate_html_class
 
 
-class HTMLNode:
+class HTMLNode(RepresentedWithVars):
     """Represents an HTML node (for example, a div or a span).
     """
 

--- a/webwidgets/utility/__init__.py
+++ b/webwidgets/utility/__init__.py
@@ -10,5 +10,6 @@
 #
 # =======================================================================
 
+from .representation import *
 from .sanitizing import *
 from .validation import *

--- a/webwidgets/utility/representation.py
+++ b/webwidgets/utility/representation.py
@@ -10,8 +10,8 @@
 #
 # =======================================================================
 
-class RepresentedWithVars:
-    """A utility class that is represented with its variables when printed.
+class ReprMixin:
+    """A mixin class that is represented with its variables when printed.
 
     For example:
 

--- a/webwidgets/utility/representation.py
+++ b/webwidgets/utility/representation.py
@@ -30,6 +30,5 @@ class RepresentedWithVars:
         :return: A string representing the class with its variables.
         :rtype: str
         """
-        variables = ', '.join(
-            f'{k}={v.__repr__()}' for k, v in vars(self).items())
+        variables = ', '.join(f'{k}={repr(v)}' for k, v in vars(self).items())
         return f"{self.__class__.__name__}({variables})"

--- a/webwidgets/utility/representation.py
+++ b/webwidgets/utility/representation.py
@@ -1,0 +1,34 @@
+# =======================================================================
+#
+#  This file is part of WebWidgets, a Python package for designing web
+#  UIs.
+#
+#  You should have received a copy of the MIT License along with
+#  WebWidgets. If not, see <https://opensource.org/license/mit>.
+#
+#  Copyright(C) 2025, mlaasri
+#
+# =======================================================================
+
+class RepresentedWithVars:
+    """A utility class that is represented with its variables when printed.
+
+    For example:
+
+    >>> class MyClass(RepresentedWithVars):
+    ...     def __init__(self, a, b):
+    ...         self.a = a
+    ...         self.b = b
+    >>> obj = MyClass(1, 2)
+    >>> print(obj)
+    MyClass(a=1, b=2)
+    """
+
+    def __repr__(self) -> str:
+        """Returns a string exposing all member variables of the class.
+
+        :return: A string representing the class with its variables.
+        :rtype: str
+        """
+        variables = ', '.join(f'{k}={v}' for k, v in vars(self).items())
+        return f"{self.__class__.__name__}({variables})"

--- a/webwidgets/utility/representation.py
+++ b/webwidgets/utility/representation.py
@@ -30,5 +30,6 @@ class RepresentedWithVars:
         :return: A string representing the class with its variables.
         :rtype: str
         """
-        variables = ', '.join(f'{k}={v}' for k, v in vars(self).items())
+        variables = ', '.join(
+            f'{k}={v.__repr__()}' for k, v in vars(self).items())
         return f"{self.__class__.__name__}({variables})"


### PR DESCRIPTION
- Implemented new functionality to allow for custom rule naming strategies instead of the default `"r0"`, `"r1"`, etc.
- Implemented `ReprMixin` for printing objects and debugging