### PR TITLE
Added support for negative indent levels

### DIFF
--- a/tests/compilation/test_html_node.py
+++ b/tests/compilation/test_html_node.py
@@ -275,6 +275,28 @@ class TestHTMLNode:
             indent_size=indent_size, indent_level=indent_level)
         assert actual_html == expected_html
 
+    @pytest.mark.parametrize("indent_level", [-3, -2, -1])
+    def test_negative_indent_level(self, indent_level: int):
+        node = HTMLNode(children=[
+            RawText('child1'),
+            RawText('child2'),
+            HTMLNode(children=[
+                RawText('grandchild1'),
+                RawText('grandchild2')
+            ])
+        ])
+        expected_html = "\n".join([
+            "<htmlnode>",
+            "child1",
+            "child2",
+            "<htmlnode>",
+            f"{'    ' if indent_level == -1 else ''}grandchild1",
+            f"{'    ' if indent_level == -1 else ''}grandchild2",
+            "</htmlnode>",
+            "</htmlnode>"
+        ])
+        assert node.to_html(indent_level=indent_level) == expected_html
+
     def test_collapse_empty(self):
         node = HTMLNode(children=[
             TestHTMLNode.CustomNode(),

--- a/tests/utility/test_indentation.py
+++ b/tests/utility/test_indentation.py
@@ -1,0 +1,29 @@
+# =======================================================================
+#
+#  This file is part of WebWidgets, a Python package for designing web
+#  UIs.
+#
+#  You should have received a copy of the MIT License along with
+#  WebWidgets. If not, see <https://opensource.org/license/mit>.
+#
+#  Copyright(C) 2025, mlaasri
+#
+# =======================================================================
+
+import pytest
+from webwidgets.utility.indentation import get_indentation
+
+
+class TestIndentation:
+    @pytest.mark.parametrize("indent_level", [0, 1, 2])
+    @pytest.mark.parametrize("indent_size", [3, 4, 8])
+    def test_get_indentation(self, indent_level: int, indent_size: int):
+        """Tests get_indentation with different indentation levels and sizes."""
+        expected_indentation = ' ' * indent_size * indent_level
+        assert get_indentation(
+            indent_level, indent_size) == expected_indentation
+
+    @pytest.mark.parametrize("indent_level", [-2, -1, 0])
+    @pytest.mark.parametrize("indent_size", [3, 4, 8])
+    def test_get_indentation_for_negative_levels(self, indent_level, indent_size):
+        assert get_indentation(indent_level, indent_size) == ''

--- a/webwidgets/compilation/html/html_node.py
+++ b/webwidgets/compilation/html/html_node.py
@@ -13,6 +13,7 @@
 import copy
 import itertools
 from typing import Any, Dict, List, Union
+from webwidgets.utility.indentation import get_indentation
 from webwidgets.utility.representation import ReprMixin
 from webwidgets.utility.sanitizing import sanitize_html_text
 from webwidgets.utility.validation import validate_html_class
@@ -153,7 +154,8 @@ class HTMLNode(ReprMixin):
         :rtype: str or List[str]
         """
         # Opening the element
-        indentation = "" if force_one_line else ' ' * indent_size * indent_level
+        indentation = "" if force_one_line else get_indentation(
+            indent_level, indent_size)
         html_lines = [indentation + self.start_tag]
 
         # If content must be in one line
@@ -266,7 +268,7 @@ class RawText(HTMLNode):
         """
         sanitized = sanitize_html_text(
             self.text, replace_all_entities=replace_all_entities)
-        line = ' ' * indent_size * indent_level + sanitized
+        line = get_indentation(indent_level, indent_size) + sanitized
         if return_lines:
             return [line]
         return line

--- a/webwidgets/compilation/html/html_node.py
+++ b/webwidgets/compilation/html/html_node.py
@@ -24,21 +24,6 @@ class HTMLNode(ReprMixin):
 
     one_line: bool = False
 
-    @staticmethod
-    def get_indentation(indent_level: int, indent_size: int = 4) -> str:
-        """Returns an indentation string for the given level.
-
-        :param indent_level: The level of indentation. If negative, this
-            function will return an empty string representing no indentation.
-        :type indent_level: int
-        :param indent_size: The number of spaces to use for each indentation
-            level. Defaults to 4 spaces.
-        :type indent_size: int
-        :return: A string representing the indentation.
-        :rtype: str
-        """
-        return ' ' * max(indent_level, 0) * indent_size
-
     def __init__(self, children: List['HTMLNode'] = None,
                  attributes: Dict[str, str] = None, style: Dict[str, str] = None):
         """Creates an HTMLNode with optional children, attributes, and style.

--- a/webwidgets/compilation/html/html_node.py
+++ b/webwidgets/compilation/html/html_node.py
@@ -139,7 +139,14 @@ class HTMLNode(ReprMixin):
         :type collapse_empty: bool
         :param indent_size: The number of spaces to use for each indentation level.
         :type indent_size: int
-        :param indent_level: The current level of indentation in the HTML output.
+        :param indent_level: The current level of indentation in the HTML
+            output.
+
+            This argument supports negative values as a way to flatten the HTML
+            output down to a certain depth with indentation resuming as normal
+            afterwards. If negative, `indent_level` is construed as an offset
+            on the depth in the HTML tree represented by the node, in which
+            case the node will wait for that depth before starting indentation.
         :type indent_level: int
         :param force_one_line: If True, forces all child elements to be rendered on a single line without additional
             indentation. Defaults to False.

--- a/webwidgets/compilation/html/html_node.py
+++ b/webwidgets/compilation/html/html_node.py
@@ -24,6 +24,21 @@ class HTMLNode(ReprMixin):
 
     one_line: bool = False
 
+    @staticmethod
+    def get_indentation(indent_level: int, indent_size: int = 4) -> str:
+        """Returns an indentation string for the given level.
+
+        :param indent_level: The level of indentation. If negative, this
+            function will return an empty string representing no indentation.
+        :type indent_level: int
+        :param indent_size: The number of spaces to use for each indentation
+            level. Defaults to 4 spaces.
+        :type indent_size: int
+        :return: A string representing the indentation.
+        :rtype: str
+        """
+        return ' ' * max(indent_level, 0) * indent_size
+
     def __init__(self, children: List['HTMLNode'] = None,
                  attributes: Dict[str, str] = None, style: Dict[str, str] = None):
         """Creates an HTMLNode with optional children, attributes, and style.

--- a/webwidgets/utility/__init__.py
+++ b/webwidgets/utility/__init__.py
@@ -10,6 +10,7 @@
 #
 # =======================================================================
 
+from .indentation import *
 from .representation import *
 from .sanitizing import *
 from .validation import *

--- a/webwidgets/utility/indentation.py
+++ b/webwidgets/utility/indentation.py
@@ -1,0 +1,25 @@
+# =======================================================================
+#
+#  This file is part of WebWidgets, a Python package for designing web
+#  UIs.
+#
+#  You should have received a copy of the MIT License along with
+#  WebWidgets. If not, see <https://opensource.org/license/mit>.
+#
+#  Copyright(C) 2025, mlaasri
+#
+# =======================================================================
+
+def get_indentation(level: int, size: int = 4) -> str:
+    """Returns an indentation string for the given level.
+
+    :param level: The level of indentation. If negative, this
+        function will return an empty string representing no indentation.
+    :type level: int
+    :param size: The number of spaces to use for each indentation level.
+        Defaults to 4 spaces.
+    :type size: int
+    :return: A string representing the indentation.
+    :rtype: str
+    """
+    return ' ' * (max(level, 0) * size)


### PR DESCRIPTION
Added support for negative indent levels, which are treated as offsets on the depth at which to start indentation. This feature will be useful for top-level HTML nodes, like the root HTML document itself, and any raw HTML node as well.